### PR TITLE
mkimage/mkknlimg: restore --dtok

### DIFF
--- a/mkimage/mkknlimg
+++ b/mkimage/mkknlimg
@@ -62,6 +62,7 @@ if ($res)
 {
     print("Version: $res->{''}\n");
 
+    $append_trailer = $dtok;
     if (!$dtok)
     {
 	if (config_bool($res, 'bcm2708_fb'))


### PR DESCRIPTION
Commit dc910bf (mkknlimg: Fix for bcm2708-pinctrl removal and unxz
breakage) broke the --dtok flag.

Restore it.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
Cc: Phil Elwell <phil@raspberrypi.org>