### PR TITLE
armstubs: Add wfe to ARMv7/ARMv8-32 stubs

### DIFF
--- a/armstubs/armstub7.S
+++ b/armstubs/armstub7.S
@@ -107,6 +107,7 @@ jmp_loader:
 
 	add	r5, #(0x400000CC-0x4000008C)	@ mbox
 1:
+	wfe
 	ldr	r4, [r5, r0, lsl #4]
 	cmp	r4, r3
 	beq	1b


### PR DESCRIPTION
[ N.B. Don't merge this without first ensuring the kernel-side patch has propagated far enough, ideally upstream. ]

This patch causes secondary CPUs to enter a low power state while
waiting to be woken during booting. Without the corresponding kernel
patch to send an event, the secondary CPUs won't come online.

See: https://github.com/raspberrypi/linux/issues/1989

Signed-off-by: Phil Elwell <phil@raspberrypi.org>