### PR TITLE
 armstub7: Various fixes

### DIFF
--- a/armstubs/armstub7.S
+++ b/armstubs/armstub7.S
@@ -78,9 +78,6 @@ jmp_loader:
 	orr r0, r0, #(1<<12)      @ icache enable
 	mcr p15, 0, r0, c1, c0, 0 @ Write System Control Register
 
-	mov r0, #1
-	mcr p15, 0, r0, c14, c3, 1 @ CNTV_CTL (enable=1, imask=0)
-
 @ set to non-sec
 	ldr	r1, value			@ value = 0x60c00 in A7, 0xc00 in A53
 	mcr	p15, 0, r1, c1, c1, 2		@ NSACR = all copros to non-sec

--- a/armstubs/armstub7.S
+++ b/armstubs/armstub7.S
@@ -57,10 +57,6 @@ mbox: 	.word 0x4000008C
 jmp_loader:
 @ Check which proc we are and run proc 0 only
 
-	mrc p15, 0, r0, c1, c0, 0 @ Read System Control Register
-	bic r0, r0, #((1<<2)|(1<<0)) @ dcache and MMU disable
-	orr r0, r0, #(1<<12)      @ icache enable
-	mcr p15, 0, r0, c1, c0, 0 @ Write System Control Register
 .if !BCM2710
 	mrc p15, 0, r0, c1, c0, 1 @ Read Auxiliary Control Register
 	orr r0, r0, #(1<<6)       @ SMP
@@ -70,6 +66,12 @@ jmp_loader:
 	orr r0, r0, #(1<<6)       @ SMP
 	mcrr p15, 1, r0, r1, c15  @ CPU Extended Control Register
 .endif
+
+@ SMP must be set before enabling the caches in both A7 and A53
+	mrc p15, 0, r0, c1, c0, 0 @ Read System Control Register
+	bic r0, r0, #((1<<2)|(1<<0)) @ dcache and MMU disable
+	orr r0, r0, #(1<<12)      @ icache enable
+	mcr p15, 0, r0, c1, c0, 0 @ Write System Control Register
 
 	mov r0, #1
 	mcr p15, 0, r0, c14, c3, 1 @ CNTV_CTL (enable=1, imask=0)

--- a/armstubs/armstub7.S
+++ b/armstubs/armstub7.S
@@ -50,7 +50,12 @@ _secure_monitor:
 	msr     spsr_cxfs, r0                   @ Set full SPSR
 	movs	pc, lr				@ return to non-secure SVC
 
-value:	.word 0x63fff
+.if !BCM2710
+value:	.word 0x60c00
+.else
+value:	.word 0xc00
+.endif
+
 machid:	.word 3138
 mbox: 	.word 0x4000008C
 
@@ -77,7 +82,7 @@ jmp_loader:
 	mcr p15, 0, r0, c14, c3, 1 @ CNTV_CTL (enable=1, imask=0)
 
 @ set to non-sec
-	ldr	r1, value			@ value = 0x63fff
+	ldr	r1, value			@ value = 0x60c00 in A7, 0xc00 in A53
 	mcr	p15, 0, r1, c1, c1, 2		@ NSACR = all copros to non-sec
 @ timer frequency
 	ldr	r1, osc				@ osc = 19200000

--- a/armstubs/armstub7.S
+++ b/armstubs/armstub7.S
@@ -58,7 +58,7 @@ jmp_loader:
 @ Check which proc we are and run proc 0 only
 
 	mrc p15, 0, r0, c1, c0, 0 @ Read System Control Register
-	orr r0, r0, #(1<<2)       @ cache enable
+	bic r0, r0, #((1<<2)|(1<<0)) @ dcache and MMU disable
 	orr r0, r0, #(1<<12)      @ icache enable
 	mcr p15, 0, r0, c1, c0, 0 @ Write System Control Register
 .if !BCM2710


### PR DESCRIPTION
Various fixes to armstub7.

Original message:
> The previous code was enabling both I and D-caches, but keeping the
> bit M as the reset value, which is architecturally undetermined. In
> practice, in both Cortex-A7 and Cortex-A53, the reset value is 0, so
> the D-cache was disabled (but the I-cache was enabled).
> 
> For the 32-bit Arm architecture boot, the Linux kernel expects the data
> cache and MMU to be disabled when the CPU jumps into it, the I-cache
> doesn't matter, as specified in the file `Documentation/arm/Booting` of
> the Linux kernel tree under `Calling the kernel image`.
> 
> This patch disables the D-cache and MMU for correctness while keeping
> the I-cache enabled to save a few cycles during the execution of the
> stub.

Fixes https://github.com/raspberrypi/tools/issues/84