### PR TITLE
armstub8: do not use GIC values for non-GIC devices

### DIFF
--- a/armstubs/Makefile
+++ b/armstubs/Makefile
@@ -21,7 +21,7 @@ clean :
 	$(CC8) -c $< -o $@
 
 %8-gic.o: %8.S
-	$(CC8) -DGIC=1 -c $< -o $@
+	$(CC8) -DGIC=1 -DBCM2711=1 -c $< -o $@
 
 %8-32.o: %7.S
 	$(CC) -DBCM2710=1 -c $< -o $@

--- a/armstubs/armstub8.S
+++ b/armstubs/armstub8.S
@@ -29,12 +29,21 @@
 
 #define BIT(x) (1 << (x))
 
+#ifdef GIC
 #define LOCAL_CONTROL		0xff800000
 #define LOCAL_PRESCALER		0xff800008
+#else
+#define LOCAL_CONTROL		0x40000000
+#define LOCAL_PRESCALER		0x40000008
+#endif
 #define GIC_DISTB		0xff841000
 #define GIC_CPUB		0xff842000
 
+#ifdef GIC
 #define OSC_FREQ		54000000
+#else
+#define OSC_FREQ		19200000
+#endif
 
 #define SCR_RW			BIT(10)
 #define SCR_HCE			BIT(8)

--- a/armstubs/armstub8.S
+++ b/armstubs/armstub8.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2016-2019 Raspberry Pi (Trading) Ltd.
  * Copyright (c) 2016 Stephen Warren <swarren@wwwdotorg.org>
  * All rights reserved.
  *
@@ -29,7 +29,7 @@
 
 #define BIT(x) (1 << (x))
 
-#ifdef GIC
+#if BCM2711
 #define LOCAL_CONTROL		0xff800000
 #define LOCAL_PRESCALER		0xff800008
 #else
@@ -39,7 +39,7 @@
 #define GIC_DISTB		0xff841000
 #define GIC_CPUB		0xff842000
 
-#ifdef GIC
+#if BCM2711
 #define OSC_FREQ		54000000
 #else
 #define OSC_FREQ		19200000


### PR DESCRIPTION
The new values could severely slow down booting (or actually, time, as even timeouts would be slowed down), specifically when booting FreeBSD with u-boot EFI on a RPI 3B+ (before the kernel kicks in). Therefore, revert to the old values when GIC is not enabled.

For the record, the issue could be specific to / reproducible only on RPI 3B+, or BCM2837B0 (i.e. and 3A+). I assume the old values would do for BCM2837 (i.e. the 1.2GHz older variant) as well anyway.