### PR TITLE
add Cortex-A72 Spectre v4 (CVE-2018-3639) mitigation

### DIFF
--- a/armstubs/Makefile
+++ b/armstubs/Makefile
@@ -1,4 +1,4 @@
-BINS=armstub.bin armstub7.bin armstub8-32.bin armstub8-32-gic.bin armstub8.bin armstub8-gic.bin armstub8-gic-highperi.bin
+BINS=armstub.bin armstub7.bin armstub8-32.bin armstub8-32-gic.bin armstub8.bin armstub8-gic.bin armstub8-gic-highperi.bin armstub8-gic-spectrev4.bin
 
 CC8?=aarch64-linux-gnu-gcc
 LD8?=aarch64-linux-gnu-ld
@@ -26,6 +26,9 @@ clean :
 %8-gic-highperi.o: %8.S
 	$(CC8) -DGIC=1 -DHIGH_PERI=1 -DBCM2711=1 -c $< -o $@
 
+%8-gic-spectrev4.o: %8.S
+	$(CC8) -DGIC=1 -DSPECTRE_V4=1 -DBCM2711=1 -c $< -o $@
+
 %8-32.o: %7.S
 	$(CC7) -DBCM2710=1 -c $< -o $@
 
@@ -41,6 +44,9 @@ clean :
 %8-gic-highperi.elf: %8-gic-highperi.o
 	$(LD8) --section-start=.text=0 $< -o $@
 
+%8-gic-spectrev4.elf: %8-gic-spectrev4.o
+	$(LD8) --section-start=.text=0 $< -o $@
+
 %8.elf: %8.o
 	$(LD8) --section-start=.text=0 $< -o $@
 
@@ -51,6 +57,9 @@ clean :
 	$(OBJCOPY8) $< -O binary $@
 
 %8-gic-highperi.tmp: %8-gic-highperi.elf
+	$(OBJCOPY8) $< -O binary $@
+
+%8-gic-spectrev4.tmp: %8-gic-spectrev4.elf
 	$(OBJCOPY8) $< -O binary $@
 
 %8.tmp: %8.elf

--- a/armstubs/armstub8.S
+++ b/armstubs/armstub8.S
@@ -68,6 +68,9 @@
 #define ACTLR_VAL \
 	(BIT(0) | BIT(1) | BIT(4) | BIT(5) | BIT(6))
 
+#define CPUACTLR_EL1		S3_1_C15_C2_0
+#define CPUACTLR_EL1_DLPS	BIT(55)
+
 #define CPUECTLR_EL1		S3_1_C15_C2_1
 #define CPUECTLR_EL1_SMPEN	BIT(6)
 
@@ -129,6 +132,12 @@ _start:
 	/* Set SMPEN */
 	mov x0, #CPUECTLR_EL1_SMPEN
 	msr CPUECTLR_EL1, x0
+
+#ifdef SPECTRE_V4
+	/* mitigate Spectre v4 */
+	mov x0, #CPUACTLR_EL1_DLPS
+	msr CPUACTLR_EL1, x0
+#endif
 
 #ifdef GIC
         bl      setup_gic


### PR DESCRIPTION
[mitigate Spectre v4](https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability):

> For Cortex-A57 and Cortex-A72:
> * Set bit 55 (disable load pass store) of CPUACTLR_EL1 (S3_1_C15_C2_0).