### PR TITLE
armstub8: Initialize CPTR_EL3 with zeros

### DIFF
--- a/armstubs/armstub8.S
+++ b/armstubs/armstub8.S
@@ -115,9 +115,8 @@ _start:
 	msr CNTVOFF_EL2, xzr
 
 	/* Enable FP/SIMD */
-	/* All set bits below are res1; bit 10 (TFP) is set to 0 */
-	mov x0, #0x33ff
-	msr CPTR_EL3, x0
+	/* Bit 10 (TFP) is set to 0 */
+	msr CPTR_EL3, xzr
 
 	/* Set up SCR */
 	mov x0, #SCR_VAL


### PR DESCRIPTION
In both Cortex A53 and A72, every bit of CPTR_EL3 is RES0 except bit 10 and bit 31.
We need bit 10 to be 0, also bit 31 is 0 previously. So zero the entire register in initialization.
Issue raspberrypi#95 pointed this out as well.