### PR TITLE
Adding fix for issue #128: Cross compilation error in armstub.S

### DIFF
--- a/armstubs/armstub.S
+++ b/armstubs/armstub.S
@@ -32,7 +32,7 @@ _start:
 	ldrd	r2, r3, atags @ loads atags into r2 and kernel into r3
 	mov	r0, #0
 	ldr	r1, machid
-	bx	pc, r3
+	bx	r3
 
 machid:	.word 3138
 


### PR DESCRIPTION
This PR fixes the cross compilation error for armstub.S [wrong branch instruction] 